### PR TITLE
feat: Entity 클래스 정의 및 초기 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,3 +233,7 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,intellij+all,visualstudiocode,gradle
+
+src/main/resources/application-prod.yml
+develop/docker-compose.yml
+/develop/

--- a/src/main/java/com/verdict/verdict/config/PersistenceConfig.java
+++ b/src/main/java/com/verdict/verdict/config/PersistenceConfig.java
@@ -1,0 +1,9 @@
+package com.verdict.verdict.config;
+
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configurable
+@EnableJpaAuditing
+public class PersistenceConfig {
+}

--- a/src/main/java/com/verdict/verdict/controller/PostController.java
+++ b/src/main/java/com/verdict/verdict/controller/PostController.java
@@ -1,0 +1,24 @@
+package com.verdict.verdict.controller;
+
+import com.verdict.verdict.dto.ApiResponse;
+import com.verdict.verdict.dto.response.PostExampleResponse;
+import com.verdict.verdict.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/posts")
+@RestController
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping("/example")
+    public ResponseEntity<ApiResponse<PostExampleResponse>> example() {
+        PostExampleResponse response = new PostExampleResponse("text");
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/ApiResponse.java
+++ b/src/main/java/com/verdict/verdict/dto/ApiResponse.java
@@ -1,0 +1,43 @@
+package com.verdict.verdict.dto;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponse<T> {
+
+    private int code;
+    private HttpStatus status;
+    private Object message;
+    private T data;
+
+    public ApiResponse(int code, HttpStatus status, Object message, T data) {
+        this.code = code;
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public ApiResponse(HttpStatus status, Object message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.data = data;
+        this.message = message;
+    }
+
+    public static <T> ApiResponse<T> of(int code, HttpStatus status, Object message, T data) {
+        return new ApiResponse<>(code, status, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, Object message, T data) {
+        return new ApiResponse<>(httpStatus, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+        return of(httpStatus, httpStatus.name(), data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, data);
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/response/PostExampleResponse.java
+++ b/src/main/java/com/verdict/verdict/dto/response/PostExampleResponse.java
@@ -1,0 +1,11 @@
+package com.verdict.verdict.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class PostExampleResponse {
+
+    private String text;
+}

--- a/src/main/java/com/verdict/verdict/entity/BaseEntity.java
+++ b/src/main/java/com/verdict/verdict/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}
+

--- a/src/main/java/com/verdict/verdict/entity/Comment.java
+++ b/src/main/java/com/verdict/verdict/entity/Comment.java
@@ -1,0 +1,34 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Comment extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "post_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    private String  content;
+
+    @Builder
+    public Comment(String content, Long id, Post post, User user) {
+        this.content = content;
+        this.id = id;
+        this.post = post;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/Post.java
+++ b/src/main/java/com/verdict/verdict/entity/Post.java
@@ -1,0 +1,41 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Post extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    private String title;
+
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private LocalDateTime closedAt;
+
+    @Builder
+    public Post(LocalDateTime closedAt, String content, Long id, Status status, String title, User user) {
+        this.closedAt = closedAt;
+        this.content = content;
+        this.id = id;
+        this.status = status;
+        this.title = title;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/Role.java
+++ b/src/main/java/com/verdict/verdict/entity/Role.java
@@ -1,0 +1,17 @@
+package com.verdict.verdict.entity;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum Role {
+    ROLE_USER, ROLE_ADMIN;
+
+    public static Role of(String role) {
+        return Arrays.stream(Role.values())
+                .filter(r -> r.name().equalsIgnoreCase(role))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("유효하지 않은 Role"));
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/Status.java
+++ b/src/main/java/com/verdict/verdict/entity/Status.java
@@ -1,0 +1,14 @@
+package com.verdict.verdict.entity;
+
+import java.util.Arrays;
+
+public enum Status {
+    PROGRESS, COMPLETED;
+
+    public static Status of(String status) {
+        return Arrays.stream(Status.values())
+                .filter(r -> r.name().equalsIgnoreCase(status))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("유효하지 않은 Status"));
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/User.java
+++ b/src/main/java/com/verdict/verdict/entity/User.java
@@ -1,0 +1,31 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class User extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    private String imageUrl;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Builder
+    public User(String email, Long id, String imageUrl, String password, Role role) {
+        this.email = email;
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.password = password;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/Vote.java
+++ b/src/main/java/com/verdict/verdict/entity/Vote.java
@@ -1,0 +1,31 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Vote extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "post_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @JoinColumn(name = "vote_option_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private VoteOption voteOption;
+
+    @Builder
+    public Vote(Long id, User user, VoteOption voteOption) {
+        this.id = id;
+        this.user = user;
+        this.voteOption = voteOption;
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/VoteOption.java
+++ b/src/main/java/com/verdict/verdict/entity/VoteOption.java
@@ -1,0 +1,32 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class VoteOption extends BaseEntity{
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "post_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    private String name;
+
+    private Integer count;
+
+    @Builder
+    public VoteOption(Integer count, Long id, String name, Post post) {
+        this.count = count;
+        this.id = id;
+        this.name = name;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/verdict/verdict/repository/CommentRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.verdict.verdict.repository;
+
+import com.verdict.verdict.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/verdict/verdict/repository/PostRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.verdict.verdict.repository;
+
+import com.verdict.verdict.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/verdict/verdict/repository/UserRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.verdict.verdict.repository;
+
+import com.verdict.verdict.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/verdict/verdict/repository/VoteOptionRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/VoteOptionRepository.java
@@ -1,0 +1,7 @@
+package com.verdict.verdict.repository;
+
+import com.verdict.verdict.entity.VoteOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteOptionRepository extends JpaRepository<VoteOption, Long> {
+}

--- a/src/main/java/com/verdict/verdict/repository/VoteRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/VoteRepository.java
@@ -1,0 +1,7 @@
+package com.verdict.verdict.repository;
+
+import com.verdict.verdict.entity.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+}

--- a/src/main/java/com/verdict/verdict/service/PostService.java
+++ b/src/main/java/com/verdict/verdict/service/PostService.java
@@ -1,0 +1,14 @@
+package com.verdict.verdict.service;
+
+import com.verdict.verdict.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class PostService {
+
+    private final PostRepository postRepository;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,16 @@
 spring:
   application:
     name: verdict
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${LOCAL_DB_USERNAME}
+    password: ${LOCAL_DB_PASSWORD}
+    url: ${LOCAL_DB_URL}
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        show_sql: true
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
## 개요
Entity 클래스 정의 및 초기 구현을 하였습니다.

## 주요 변경사항
* Entity 클래스 정의 및 구현
* 공통 응답 DTO 구현
*  JpaRepository 추가
* 예시를 위한 임시 코드 추가
  * `PostController` 의 `example()` 메서드

## 상세 내용
앞으로 모든 API 의 응답은 공통 응답 DTO 인 `ApiResponse` 로 이루어집니다.
`PostController` 의 `example()` 메서드를 참고하시면 좋습니다.

## 관련 이슈
This closes #1 