### PR TITLE
feat: implement OAuth2 authentication with Google and Naver, update application configuration  User.java에 provider,providerId 추가.  UserRepository.java에 이멜조회 메서드 추가.  CustomAuthUserService.java 생성.  response 로직은 팀원간 상의 후 구현 예정.  UserService는 여기서 다 처리 될듯.  AuthController.java 생성.  이 역시 UserController로 퉁치게될듯

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'org.webjars:swagger-ui:5.25.2'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
+	implementation('some:dependency') {
+		exclude group: 'commons-logging', module: 'commons-logging'
+	}
 }
 
 tasks.named('test') {

--- a/src/main/java/com/verdict/verdict/VerdictApplication.java
+++ b/src/main/java/com/verdict/verdict/VerdictApplication.java
@@ -2,6 +2,7 @@ package com.verdict.verdict;
 
 import io.github.cdimascio.dotenv.Dotenv;
 import io.github.cdimascio.dotenv.DotenvEntry;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.core.env.MapPropertySource;
@@ -16,7 +17,7 @@ public class VerdictApplication {
 
 	public static void main(String[] args) {
 		Map<String, Object> env = Dotenv.configure()
-				.directory("src/main/resources/.env")
+				.directory("src/main/resources")
 				.ignoreIfMalformed()
 				.ignoreIfMissing()
 				.load()
@@ -27,7 +28,7 @@ public class VerdictApplication {
 		new SpringApplicationBuilder(VerdictApplication.class)
 				.environment(new StandardEnvironment() {
 					@Override
-					protected void customizePropertySources(MutablePropertySources propertySources) {
+					protected void customizePropertySources(@NotNull MutablePropertySources propertySources) {
 						super.customizePropertySources(propertySources);
 						propertySources.addLast(new MapPropertySource("dotenvProperties", env));
 					}

--- a/src/main/java/com/verdict/verdict/controller/AuthController.java
+++ b/src/main/java/com/verdict/verdict/controller/AuthController.java
@@ -1,0 +1,38 @@
+package com.verdict.verdict.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+
+
+    @GetMapping("/google")
+    public ResponseEntity<String> googleAuth(@RegisteredOAuth2AuthorizedClient("google") OAuth2AuthorizedClient authorizedClient, OAuth2AuthenticationToken authentication) {
+        OAuth2User user = authentication.getPrincipal();
+        log.info("Google user: {}", user.getAttributes());
+        log.info("Access Token: {}", authorizedClient.getAccessToken().getTokenValue());
+        return ResponseEntity.ok("google endpoint test");
+
+    }
+
+    @GetMapping("/naver")
+    public ResponseEntity<String> naverAuth(@RegisteredOAuth2AuthorizedClient("naver") OAuth2AuthorizedClient authorizedClient, OAuth2AuthenticationToken authentication) {
+        OAuth2User user = authentication.getPrincipal();
+        log.info("Naver user: {}", user.getAttributes());
+        log.info("Access Token: {}", authorizedClient.getAccessToken().getTokenValue());
+        return ResponseEntity.ok("naver endpoint test");
+    }
+}

--- a/src/main/java/com/verdict/verdict/controller/TestComponent.java
+++ b/src/main/java/com/verdict/verdict/controller/TestComponent.java
@@ -1,0 +1,38 @@
+package com.verdict.verdict.controller;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+public class TestComponent {
+
+    @Value("${GOOGLE_CLIENT_ID}")
+    private String googleClientId;
+    @Value("${GOOGLE_CLIENT_SECRET}")
+    private String googleClientSecret;
+    @Value("${NAVER_CLIENT_ID}")
+    private String naverClientId;
+    @Value("${NAVER_CLIENT_SECRET}")
+    private String naverClientSecret;
+    @Value("${DEV_CLIENT_URL}")
+    private String frontServerUrl;
+
+
+    public void EnvInfo() {
+        log.info("연결된 프론트 서버 : {}", frontServerUrl);
+    }
+
+
+    public void init() {
+        if (googleClientId.isEmpty() && googleClientSecret.isEmpty() && naverClientId.isEmpty() && naverClientSecret.isEmpty()) {
+            log.warn("GOOGLE_CLIENT_ID: {}, GOOGLE_CLIENT_SECRET: {}, NAVER_CLIENT_ID: {}, NAVER_CLIENT_SECRET: {}", googleClientId, googleClientSecret, naverClientId, naverClientSecret);
+        } else {
+            EnvInfo();
+        }
+
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/User.java
+++ b/src/main/java/com/verdict/verdict/entity/User.java
@@ -19,13 +19,21 @@ public class User extends BaseEntity{
 
     @Enumerated(EnumType.STRING)
     private Role role;
+    // provider
+    private String provider;
+
+    // providerId : oauth 로그인 한 유저의 고유 ID
+    private String providerId;
+
 
     @Builder
-    public User(String email, Long id, String imageUrl, String password, Role role) {
+    public User(String email, Long id, String imageUrl, String password, Role role, String provider, String providerId) {
         this.email = email;
         this.id = id;
         this.imageUrl = imageUrl;
         this.password = password;
         this.role = role;
+        this.provider = "google"; // 임시로 google만.
+        this.providerId = String.valueOf(id); // providerId는 id로 설정
     }
 }

--- a/src/main/java/com/verdict/verdict/repository/UserRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/UserRepository.java
@@ -2,6 +2,9 @@ package com.verdict.verdict.repository;
 
 import com.verdict.verdict.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/verdict/verdict/service/CustomAuthUserService.java
+++ b/src/main/java/com/verdict/verdict/service/CustomAuthUserService.java
@@ -1,0 +1,43 @@
+package com.verdict.verdict.service;
+
+import com.verdict.verdict.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+
+
+import java.util.Map;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomAuthUserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String clientName = userRequest.getClientRegistration().getRegistrationId();
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails()
+                .getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        return new DefaultOAuth2User(
+                oAuth2User.getAuthorities(),
+                attributes,
+                userNameAttributeName
+        );
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,12 @@
 server:
   port: 8080
 front-server:
-  url: ${DEV_SERVER_URL}
+    port: ${DEV_CLIENT_URL}
 
 spring:
-  application:
-    name: verdict
+  config:
+    import:
+        - classpath:keys.yml
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${LOCAL_DB_USERNAME}
@@ -14,9 +15,9 @@ spring:
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
-        show_sql: true
+#        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: false # true, false
+        show_sql: false # true, false
     hibernate:
       ddl-auto: none # create, create-drop, update, validate, none
 

--- a/src/main/resources/keys.yml
+++ b/src/main/resources/keys.yml
@@ -1,0 +1,29 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+              - profile
+              - email
+            redirect-uri: "{baseUrl}/login/oauth2/code/google"
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
+              - profile_image
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response


### PR DESCRIPTION
## 📝 개요
변경 사항 및 목적을 간단히 설명

> 구글,네이버 OAuth2 인증을 포함한 User 기능 일부 수정, 추가
 

## ✨ 주요 변경사항
핵심적으로 달라진 점(기능 추가, 리팩토링, 버그 수정 등)

> - CORS 통신 정상작동.
> - 요구사항에 따른 UserService 로직 구현. 
> - 기존 구글 API키 폐기 후 재발급하여 스프링 버그 수정    
 
 
## 📌 기타
참고해야 할 사항, 스크린샷, 논의점 등

> [!note]+ 논의 사항
> 1. "verdict.gg\client\src\app\(auth)\login\page.tsx" 파일 수정으로 CORS 오류 해결을 한 경험을 프론트 담당자 에게 얘기하여 이에 대한 조언을 얻고자함.
> 2. 서버 작업 또한 인프라 구축 담당자와 환경변수 관리 방법에 대해 건의사항 전달코자 함.
> 
> 3. 이 외 참고사항이 있는데, 위 논의점에 포함될 내용이므로 회의할 때 얘기하겠음. 

## 🔗 관련 이슈
feat/#2 