### PR TITLE
PR: feat/#4 

### DIFF
--- a/src/main/java/com/verdict/verdict/config/WebSecurityConfig.java
+++ b/src/main/java/com/verdict/verdict/config/WebSecurityConfig.java
@@ -66,7 +66,7 @@ public class WebSecurityConfig  {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000",
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000","http://localhost:3000",
                 "https://verdict-gg.vercel.app",
                 "https://verlol.site"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/com/verdict/verdict/dto/oauth2/UserWithSignupStatus.java
+++ b/src/main/java/com/verdict/verdict/dto/oauth2/UserWithSignupStatus.java
@@ -1,0 +1,32 @@
+package com.verdict.verdict.dto.oauth2;
+
+import com.verdict.verdict.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.*;
+
+@Getter
+@AllArgsConstructor
+public class UserWithSignupStatus implements OAuth2User {
+    private final User user;
+    private final boolean isNew;
+    private final Map<String, Object> attributes;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final String nameAttributeKey;
+
+    @Override
+    public String getName() {
+        return user.getEmail(); // Return user's email as name
+    }
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities; // Return authorities
+    }
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes; // Return attributes
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/oauth2/UserWithSignupStatusTest.java
+++ b/src/main/java/com/verdict/verdict/dto/oauth2/UserWithSignupStatusTest.java
@@ -1,0 +1,82 @@
+package com.verdict.verdict.dto.oauth2;
+
+import com.verdict.verdict.entity.Role;
+import com.verdict.verdict.entity.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserWithSignupStatusTest {
+
+    @Test
+    void testGetName() {
+        // Given
+        User user = User.builder()
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+        UserWithSignupStatus userWithSignupStatus = new UserWithSignupStatus(
+                user,
+                true,
+                Map.of("email", "test@example.com"),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                "email"
+        );
+
+        // When
+        String name = userWithSignupStatus.getName();
+
+        // Then
+        assertThat(name).isEqualTo("test@example.com");
+    }
+
+    @Test
+    void testGetAuthorities() {
+        // Given
+        User user = User.builder()
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+        UserWithSignupStatus userWithSignupStatus = new UserWithSignupStatus(
+                user,
+                true,
+                Map.of("email", "test@example.com"),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                "email"
+        );
+
+        // When
+        var authorities = userWithSignupStatus.getAuthorities();
+
+        // Then
+        assertThat(authorities).hasSize(1);
+        assertThat(authorities.iterator().next().getAuthority()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    void testGetAttributes() {
+        // Given
+        User user = User.builder()
+                .email("test@example.com")
+                .role(Role.ROLE_USER)
+                .build();
+        Map<String, Object> attributes = Map.of("email", "test@example.com");
+        UserWithSignupStatus userWithSignupStatus = new UserWithSignupStatus(
+                user,
+                true,
+                attributes,
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                "email"
+        );
+
+        // When
+        Map<String, Object> resultAttributes = userWithSignupStatus.getAttributes();
+
+        // Then
+        assertThat(resultAttributes).isEqualTo(attributes);
+    }
+}

--- a/src/main/java/com/verdict/verdict/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/verdict/verdict/handler/OAuth2SuccessHandler.java
@@ -1,29 +1,38 @@
 package com.verdict.verdict.handler;
 
 
-import jakarta.servlet.ServletException;
+import com.verdict.verdict.dto.oauth2.UserWithSignupStatus;
+import com.verdict.verdict.service.CustomOAuth2UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    // @Value("${front-server.port}")
+    @Value("${front-server.url}")
     private String frontServerUrl = "https://verdict-gg.vercel.app";
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        String targetUrl = frontServerUrl;
-        log.info("redirect>>>{}", targetUrl);
-        response.sendRedirect(targetUrl);
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        UserWithSignupStatus user = (UserWithSignupStatus) authentication.getPrincipal();
+
+        if (user.isNew()) {
+            log.info("신규! 이메일주소만 뿌림!: {}", user.getUser().getEmail());
+            String email = URLEncoder.encode(user.getUser().getEmail(), "UTF-8");
+            response.sendRedirect(frontServerUrl + "/signup?email=" + email);
+        } else {
+            response.sendRedirect(frontServerUrl); //기존유저는 메인으로.
+        }
     }
 }


### PR DESCRIPTION
feat: UserWithSignupStatus for new user  CustomOAuth2UserService , OAuth2SuccessHandler에 반영.


1. ✅/login → 구글 로그인
2. ✅구글 인증 성공 → 유저 정보만 가져옴 (이메일)
3. ✅→ /signup 으로 리디렉션 + 유저 정보 전달

여기까지 진행.
 
----

4. /signup에서 사용자 추가 정보 입력 (ex. 닉네임, 약관 동의 등)
5. → 프론트에서 /api/auth/signup 같은 백엔드 API에 POST 요청
6. → 백엔드에서 회원가입 처리 + JWT 발급
7. → JWT 프론트에 전달 or 쿠키에 저장