### PR TITLE
feat: 첨부파일(이미지, 영상) 업로드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,12 @@ dependencies {
 	// implementation('some:dependency') {
 	// 	exclude group: 'commons-logging', module: 'commons-logging'
 	// }
+	// s3
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+
+	// AWS SDK BOM 추가
+	implementation platform('software.amazon.awssdk:bom:2.31.69')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/verdict/verdict/controller/AttachmentController.java
+++ b/src/main/java/com/verdict/verdict/controller/AttachmentController.java
@@ -1,0 +1,62 @@
+package com.verdict.verdict.controller;
+
+import com.verdict.verdict.dto.ApiResponse;
+import com.verdict.verdict.dto.request.VideoAbortRequest;
+import com.verdict.verdict.dto.request.VideoUploadCompletedRequest;
+import com.verdict.verdict.dto.request.VideoUploadInitRequest;
+import com.verdict.verdict.dto.response.ImageResponse;
+import com.verdict.verdict.dto.response.VideoResponse;
+import com.verdict.verdict.dto.response.VideoUploadInitResponse;
+import com.verdict.verdict.service.ImageService;
+import com.verdict.verdict.service.VideoService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/attachments")
+@RestController
+public class AttachmentController {
+
+    private final ImageService imageService;
+    private final VideoService videoService;
+
+    @Operation(summary = "S3에 이미지 업로드")
+    @PostMapping("/images")
+    public ResponseEntity<ApiResponse<ImageResponse>> uploadImage(@RequestPart MultipartFile image) {
+        ImageResponse response = imageService.save(image);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    //TODO: 게시글 생성 시 findByFileKey() 를 사용하여 DB Attachment 테이블에 저장해야함.
+
+    @Operation(summary = "S3에 영상 멀티파트 업로드 초기화 및 Pre-signed URL 목록 생성")
+    @PostMapping("/videos/init")
+    public ResponseEntity<ApiResponse<VideoUploadInitResponse>> initVideoUpload(@RequestBody VideoUploadInitRequest request) {
+        VideoUploadInitResponse response = videoService.initiateVideoUpload(request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "S3 영상 멀티파트 업로드 완료")
+    @PostMapping("/videos/complete")
+    public ResponseEntity<ApiResponse<VideoResponse>> completeVideoUpload(@RequestBody VideoUploadCompletedRequest request) {
+        VideoResponse response = videoService.completeVideoUpload(request);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @Operation(summary = "S3 영상 멀티파트 업로드 중단")
+    @PostMapping("/videos/abort")
+    public ResponseEntity<ApiResponse<Void>> abortVideoUpload(@RequestBody VideoAbortRequest request) {
+        videoService.abortVideoUpload(request.getFileKey(), request.getUploadId());
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @Operation(summary = "S3 영상 삭제")
+    @DeleteMapping("/videos/{fileKey}")
+    public ResponseEntity<ApiResponse<Void>> deleteVideo(@PathVariable String fileKey) {
+        videoService.deleteVideo(fileKey);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/CompletedPartDto.java
+++ b/src/main/java/com/verdict/verdict/dto/CompletedPartDto.java
@@ -1,0 +1,16 @@
+package com.verdict.verdict.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class CompletedPartDto {
+    private Integer partNumber;
+
+    @JsonProperty("eTag")
+    private String eTag;
+}

--- a/src/main/java/com/verdict/verdict/dto/ImageFile.java
+++ b/src/main/java/com/verdict/verdict/dto/ImageFile.java
@@ -1,0 +1,43 @@
+package com.verdict.verdict.dto;
+
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@Getter
+public class ImageFile {
+    private final MultipartFile file;
+    private final String uniqueName;
+
+    public ImageFile(MultipartFile file) {
+        validateNullImage(file);
+        this.file = file;
+        this.uniqueName = createUniqueName(file);
+    }
+
+    private void validateNullImage(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new RuntimeException("이미지가 존재하지 않습니다."); //TODO: ImageException
+        }
+    }
+
+    private String createUniqueName(MultipartFile image) {
+        String originalFilename = image.getOriginalFilename();
+        return UUID.randomUUID().toString() + "_" + originalFilename;
+    }
+
+    public String getContentType() {
+        return this.file.getContentType();
+    }
+
+    public long getSize() {
+        return this.file.getSize();
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return this.file.getInputStream();
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/ImageUploadResult.java
+++ b/src/main/java/com/verdict/verdict/dto/ImageUploadResult.java
@@ -1,0 +1,13 @@
+package com.verdict.verdict.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ImageUploadResult {
+    private String imageUrl;
+    private String fileKey;
+}

--- a/src/main/java/com/verdict/verdict/dto/request/VideoAbortRequest.java
+++ b/src/main/java/com/verdict/verdict/dto/request/VideoAbortRequest.java
@@ -1,0 +1,13 @@
+package com.verdict.verdict.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class VideoAbortRequest {
+    private String uploadId;
+    private String fileKey;
+}

--- a/src/main/java/com/verdict/verdict/dto/request/VideoUploadCompletedRequest.java
+++ b/src/main/java/com/verdict/verdict/dto/request/VideoUploadCompletedRequest.java
@@ -1,0 +1,17 @@
+package com.verdict.verdict.dto.request;
+
+import com.verdict.verdict.dto.CompletedPartDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class VideoUploadCompletedRequest {
+    private String uploadId;
+    private String fileKey;
+    private List<CompletedPartDto> completedParts;
+}

--- a/src/main/java/com/verdict/verdict/dto/request/VideoUploadInitRequest.java
+++ b/src/main/java/com/verdict/verdict/dto/request/VideoUploadInitRequest.java
@@ -1,0 +1,14 @@
+package com.verdict.verdict.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class VideoUploadInitRequest {
+    private String fileName;
+    private String contentType;
+    private Long fileSize;
+}

--- a/src/main/java/com/verdict/verdict/dto/response/ImageResponse.java
+++ b/src/main/java/com/verdict/verdict/dto/response/ImageResponse.java
@@ -1,0 +1,16 @@
+package com.verdict.verdict.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ImageResponse {
+    private String imageUrl;
+
+    public static ImageResponse of(String imageUrl) {
+        return new ImageResponse(imageUrl);
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/response/VideoResponse.java
+++ b/src/main/java/com/verdict/verdict/dto/response/VideoResponse.java
@@ -1,0 +1,15 @@
+package com.verdict.verdict.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class VideoResponse {
+    private String videoUrl;
+
+    public static VideoResponse of(String videoUrl) {
+        return new VideoResponse(videoUrl);
+    }
+}

--- a/src/main/java/com/verdict/verdict/dto/response/VideoUploadInitResponse.java
+++ b/src/main/java/com/verdict/verdict/dto/response/VideoUploadInitResponse.java
@@ -1,0 +1,22 @@
+package com.verdict.verdict.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class VideoUploadInitResponse {
+    private String uploadId;
+    private String fileKey;
+    private List<String> presignedUrls;
+    private int partCount;
+    private long partSize;
+
+    public static VideoUploadInitResponse of(String uploadId, String fileKey, List<String> presignedUrls, int partCount, long partSize) {
+        return new VideoUploadInitResponse(uploadId, fileKey, presignedUrls, partCount, partSize);
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/Attachment.java
+++ b/src/main/java/com/verdict/verdict/entity/Attachment.java
@@ -1,0 +1,50 @@
+package com.verdict.verdict.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Attachment extends BaseEntity{
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    @JoinColumn(name = "post_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    private String fileKey;
+
+    private String thumbnailUrl;
+
+    private String originalName;
+
+    private Boolean isVideo;
+
+    @Enumerated(EnumType.STRING)
+    private AttachmentStatus attachmentStatus;
+
+    private Long size;
+
+    @Builder
+    public Attachment(Long id, Boolean isVideo, String originalName, Post post, Long size, String thumbnailUrl, String fileKey, AttachmentStatus attachmentStatus) {
+        this.id = id;
+        this.isVideo = isVideo;
+        this.originalName = originalName;
+        this.post = post;
+        this.size = size;
+        this.thumbnailUrl = thumbnailUrl;
+        this.fileKey = fileKey;
+        this.attachmentStatus = attachmentStatus;
+    }
+
+    public void updateStatus(AttachmentStatus status){
+        this.attachmentStatus = status;
+    }
+}

--- a/src/main/java/com/verdict/verdict/entity/AttachmentStatus.java
+++ b/src/main/java/com/verdict/verdict/entity/AttachmentStatus.java
@@ -1,0 +1,14 @@
+package com.verdict.verdict.entity;
+
+import java.util.Arrays;
+
+public enum AttachmentStatus {
+    UPLOADING, UPLOADED, FAILED;
+
+    public static AttachmentStatus of(String status) {
+        return Arrays.stream(AttachmentStatus.values())
+                .filter(r -> r.name().equalsIgnoreCase(status))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("유효하지 않은 Status"));
+    }
+}

--- a/src/main/java/com/verdict/verdict/infrastructure/S3ImageService.java
+++ b/src/main/java/com/verdict/verdict/infrastructure/S3ImageService.java
@@ -1,0 +1,57 @@
+package com.verdict.verdict.infrastructure;
+
+import com.verdict.verdict.dto.ImageFile;
+import com.verdict.verdict.dto.ImageUploadResult;
+import io.awspring.cloud.s3.ObjectMetadata;
+import io.awspring.cloud.s3.S3Resource;
+import io.awspring.cloud.s3.S3Template;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@RequiredArgsConstructor
+@Component
+public class S3ImageService {
+
+    private final S3Template s3Template;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private static final String IMAGE_UPLOAD_PATH = "images/";
+
+    public ImageUploadResult uploadImage(ImageFile imageFile) {
+         String fileKey = IMAGE_UPLOAD_PATH + imageFile.getUniqueName();
+
+        try (InputStream inputStream = imageFile.getInputStream()) {
+            // contentType 등은 ObjectMetadataBuilder로 지정 가능
+            S3Resource upload = s3Template.upload(
+                    bucket,
+                    fileKey,
+                    inputStream,
+                    ObjectMetadata.builder()
+                            .contentType(imageFile.getContentType())
+                            .contentLength(imageFile.getSize())
+                            .build()
+            );
+            String url = upload.getURL().toString();
+
+            return new ImageUploadResult(url, fileKey);
+        } catch (IOException | RuntimeException e) {
+            throw new RuntimeException("이미지 업로드에 실패했습니다. " + e.getMessage()); //TODO: ImageException
+        }
+    }
+
+    public void deleteImage(String fileKey) {
+        if (fileKey == null || fileKey.isEmpty()) return;
+
+        try {
+            s3Template.deleteObject(bucket, fileKey);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("이미지 삭제에 실패했습니다. " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/verdict/verdict/infrastructure/S3VideoService.java
+++ b/src/main/java/com/verdict/verdict/infrastructure/S3VideoService.java
@@ -1,0 +1,142 @@
+package com.verdict.verdict.infrastructure;
+
+import com.verdict.verdict.dto.request.VideoUploadCompletedRequest;
+import com.verdict.verdict.dto.request.VideoUploadInitRequest;
+import com.verdict.verdict.dto.response.VideoUploadInitResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedUploadPartRequest;
+import software.amazon.awssdk.services.s3.presigner.model.UploadPartPresignRequest;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class S3VideoService {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private static final long PART_SIZE = 6 * 1024 * 1024; // 6mb
+    private static final String VIDEO_UPLOAD_PATH = "videos/";
+
+    // 멀티파트 업로드 초기화 및 Pre-signed URL 목록 생성
+    public VideoUploadInitResponse initiateMultipartUpload(VideoUploadInitRequest request) {
+        try {
+            String originalName = request.getFileName();
+            String fileKey = VIDEO_UPLOAD_PATH + UUID.randomUUID() + "_" + originalName;
+
+            CreateMultipartUploadRequest createRequest = CreateMultipartUploadRequest.builder()
+                    .bucket(bucket)
+                    .key(fileKey)
+                    .contentType(request.getContentType())
+                    .build();
+
+            CreateMultipartUploadResponse createResponse = s3Client.createMultipartUpload(createRequest);
+
+            // 파트 개수 계산
+            int partCount = (int) Math.ceil((double) request.getFileSize() / PART_SIZE);
+
+            // 각 파트별 Pre-signed URL 생성
+            List<String> presignedUrls = new ArrayList<>();
+            for (int i = 1; i <= partCount; i++) {
+                String url = generatePresignedUrl(fileKey, createResponse.uploadId(), i);
+                presignedUrls.add(url);
+            }
+
+            return VideoUploadInitResponse.of(
+                    createResponse.uploadId(),
+                    fileKey,
+                    presignedUrls,
+                    partCount,
+                    PART_SIZE
+            );
+        } catch (RuntimeException e) {
+            throw new RuntimeException("S3 멀티파트 업로드 초기화에 실패했습니다. " + e.getMessage()); // TODO: VideoException
+        }
+    }
+
+    // 각 파트별 Pre-signed URL 생성
+    private String generatePresignedUrl(String fileKey, String uploadId, int partNumber) {
+        UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
+                .bucket(bucket)
+                .key(fileKey)
+                .uploadId(uploadId)
+                .partNumber(partNumber)
+                .build();
+
+        UploadPartPresignRequest presignRequest = UploadPartPresignRequest.builder()
+                .signatureDuration(Duration.ofHours(1))
+                .uploadPartRequest(uploadPartRequest)
+                .build();
+
+        PresignedUploadPartRequest presignedRequest = s3Presigner.presignUploadPart(presignRequest);
+        return presignedRequest.url().toString();
+    }
+
+    // 멀티파트 업로드 완료
+    public String completeMultipartUpload(VideoUploadCompletedRequest request) {
+        try {
+            List<CompletedPart> parts = request.getCompletedParts().stream()
+                    .map(p -> CompletedPart.builder()
+                            .partNumber(p.getPartNumber())
+                            .eTag(p.getETag())
+                            .build())
+                    .collect(Collectors.toList());
+
+            CompleteMultipartUploadRequest completeRequest = CompleteMultipartUploadRequest.builder()
+                    .bucket(bucket)
+                    .key(request.getFileKey())
+                    .uploadId(request.getUploadId())
+                    .multipartUpload(CompletedMultipartUpload.builder().parts(parts).build())
+                    .build();
+
+            CompleteMultipartUploadResponse response = s3Client.completeMultipartUpload(completeRequest);
+            return response.location(); // 최종 파일의 S3 URL
+        } catch (RuntimeException e) {
+            throw new RuntimeException("멀티파트 업로드 완료에 실패했습니다. " + e.getMessage()); // TODO: VideoException
+        }
+    }
+
+    // 멀티파트 업로드 중단
+    public void abortMultipartUpload(String fileKey, String uploadId) {
+        try {
+            AbortMultipartUploadRequest request = AbortMultipartUploadRequest.builder()
+                    .bucket(bucket)
+                    .key(fileKey)
+                    .uploadId(uploadId)
+                    .build();
+            s3Client.abortMultipartUpload(request);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("멀티파트 업로드 중단에 실패했습니다. " + e.getMessage()); // TODO: VideoException
+        }
+    }
+
+    // 파일 삭제
+    public void deleteVideo(String fileKey) {
+        if (fileKey == null || fileKey.isEmpty()) return;
+
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileKey)
+                    .build();
+            s3Client.deleteObject(request);
+        }catch (RuntimeException e) {
+            throw new RuntimeException("파일 삭제에 실패했습니다. " + e.getMessage()); //TODO: VideoException
+        }
+    }
+}

--- a/src/main/java/com/verdict/verdict/repository/AttachmentRepository.java
+++ b/src/main/java/com/verdict/verdict/repository/AttachmentRepository.java
@@ -1,0 +1,10 @@
+package com.verdict.verdict.repository;
+
+import com.verdict.verdict.entity.Attachment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AttachmentRepository extends JpaRepository<Attachment, Long> {
+    Optional<Attachment> findByFileKey(String fileKey);
+}

--- a/src/main/java/com/verdict/verdict/service/ImageService.java
+++ b/src/main/java/com/verdict/verdict/service/ImageService.java
@@ -1,0 +1,50 @@
+package com.verdict.verdict.service;
+
+import com.verdict.verdict.dto.ImageFile;
+import com.verdict.verdict.dto.ImageUploadResult;
+import com.verdict.verdict.dto.response.ImageResponse;
+import com.verdict.verdict.entity.Attachment;
+import com.verdict.verdict.infrastructure.S3ImageService;
+import com.verdict.verdict.repository.AttachmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class ImageService {
+    private final S3ImageService s3ImageService;
+    private final AttachmentRepository attachmentRepository;
+
+    @Transactional
+    public ImageResponse save(MultipartFile image) {
+        validateSizeOfImage(image);
+
+        ImageFile imageFile = new ImageFile(image);
+        ImageUploadResult result = s3ImageService.uploadImage(imageFile);
+
+        Attachment attachment = Attachment.builder()
+                .fileKey(result.getFileKey())
+                .isVideo(Boolean.FALSE)
+                .size(image.getSize())
+                .originalName(image.getOriginalFilename())
+                .build();
+
+        attachmentRepository.save(attachment);
+
+        return ImageResponse.of(result.getImageUrl());
+    }
+
+    public void deleteImage(String originalUrl) {
+        s3ImageService.deleteImage(originalUrl);
+    }
+
+    private void validateSizeOfImage(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new RuntimeException("이미지가 존재하지 않습니다."); //TODO: ImageException
+        }
+    }
+}
+

--- a/src/main/java/com/verdict/verdict/service/VideoService.java
+++ b/src/main/java/com/verdict/verdict/service/VideoService.java
@@ -1,0 +1,76 @@
+package com.verdict.verdict.service;
+
+import com.verdict.verdict.dto.request.VideoUploadCompletedRequest;
+import com.verdict.verdict.dto.request.VideoUploadInitRequest;
+import com.verdict.verdict.dto.response.VideoResponse;
+import com.verdict.verdict.dto.response.VideoUploadInitResponse;
+import com.verdict.verdict.entity.Attachment;
+import com.verdict.verdict.entity.AttachmentStatus;
+import com.verdict.verdict.infrastructure.S3VideoService;
+import com.verdict.verdict.repository.AttachmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class VideoService {
+
+    private final S3VideoService s3VideoService;
+    private final AttachmentRepository attachmentRepository;
+
+    // 멀티파트 업로드 초기화 및 Pre-signed URL 목록 생성
+    @Transactional
+    public VideoUploadInitResponse initiateVideoUpload(VideoUploadInitRequest request) {
+        // 멀티파트 업로드 초기화 및 Pre-signed URL 목록 생성
+        VideoUploadInitResponse response = s3VideoService.initiateMultipartUpload(request);
+
+        Attachment attachment = Attachment.builder()
+                .originalName(request.getFileName())
+                .fileKey(response.getFileKey())
+                .size(request.getFileSize())
+                .isVideo(Boolean.TRUE)
+                .attachmentStatus(AttachmentStatus.UPLOADING)
+                .build();
+
+        attachmentRepository.save(attachment);
+
+        return response;
+    }
+
+    // 멀티파트 업로드 완료 처리
+    @Transactional
+    public VideoResponse completeVideoUpload(VideoUploadCompletedRequest request) {
+        // 멀티파트 업로드 완료 처리
+        String url = s3VideoService.completeMultipartUpload(request);
+        //TODO: AttachmentNotFoundException
+        Attachment attachment = attachmentRepository.findByFileKey(request.getFileKey()).orElseThrow(RuntimeException::new);
+
+        attachment.updateStatus(AttachmentStatus.UPLOADED);
+
+        return VideoResponse.of(url);
+    }
+
+    // 멀티파트 업로드 중단 처리
+    @Transactional
+    public void abortVideoUpload(String fileKey, String uploadId) {
+        s3VideoService.abortMultipartUpload(fileKey, uploadId);
+
+        Attachment attachment = attachmentRepository.findByFileKey(fileKey).orElseThrow(RuntimeException::new);
+        attachment.updateStatus(AttachmentStatus.FAILED);
+    }
+
+    // S3 비디오 삭제 처리
+    @Transactional
+    public void deleteVideo(String fileKey) {
+        Attachment attachment = attachmentRepository.findByFileKey(fileKey).orElseThrow(RuntimeException::new);
+
+        s3VideoService.deleteVideo(fileKey);
+
+        attachmentRepository.delete(attachment);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,16 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ${AWS_REGION}
+      s3:
+        bucket: ${AWS_S3_BUCKET}
+
 springdoc:
   api-docs:
     enabled: true  # API 문서(`/v3/api-docs`) 활성화 여부 (기본값: true)

--- a/src/main/resources/db/migration/V2__create_attachment_table.sql
+++ b/src/main/resources/db/migration/V2__create_attachment_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE attachment
+(
+    id                 BIGINT AUTO_INCREMENT NOT NULL,
+    created_at         DATETIME(6) NULL,
+    modified_at         DATETIME(6) NULL,
+    post_id            BIGINT NULL,
+    file_key           VARCHAR(255) NULL,
+    thumbnail_url      VARCHAR(255) NULL,
+    original_name      VARCHAR(255) NULL,
+    is_video           TINYINT(1) NULL,
+    attachment_status  ENUM('UPLOADING', 'UPLOADED', 'FAILED') NULL,
+    size               BIGINT NULL,
+    CONSTRAINT pk_attachment PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_file_key ON attachment (file_key);

--- a/src/main/resources/static/VideoUploadTest.html
+++ b/src/main/resources/static/VideoUploadTest.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>비디오 업로드 테스트</title>
+    <!-- Tailwind CSS CDN -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        body {
+            font-family: "Inter", sans-serif;
+            background-color: #f0f4f8;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+        }
+        .container {
+            max-width: 600px;
+            width: 100%;
+            padding: 2rem;
+            background-color: #ffffff;
+            border-radius: 1.5rem; /* Rounded corners */
+            box-shadow: 0 10px 25px rgba(0, 0, 0, 0.1);
+            border: 1px solid #e2e8f0;
+        }
+        .progress-bar {
+            width: 0%;
+            height: 100%;
+            background-color: #3b82f6; /* Blue-500 */
+            border-radius: 9999px; /* Full rounded */
+            transition: width 0.3s ease-in-out;
+        }
+    </style>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+<div class="container space-y-6">
+    <h1 class="text-3xl font-extrabold text-center text-gray-800 mb-8">비디오 업로드 테스트</h1>
+
+    <div class="mb-6">
+        <label for="fileInput" class="block text-gray-700 text-lg font-semibold mb-2">
+            파일 선택:
+        </label>
+        <input type="file" id="fileInput" accept="video/*" class="w-full px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 ease-in-out">
+    </div>
+
+    <div class="space-y-4">
+        <button id="uploadButton"
+                class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-xl shadow-lg transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-blue-300">
+            업로드 시작
+        </button>
+        <button id="abortButton"
+                class="w-full bg-red-500 hover:bg-red-600 text-white font-bold py-3 px-6 rounded-xl shadow-lg transition duration-300 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-red-300 hidden">
+            업로드 중단
+        </button>
+    </div>
+
+    <div id="progressContainer" class="mt-8 bg-gray-200 rounded-full h-8 overflow-hidden shadow-inner hidden">
+        <div class="progress-bar h-full text-center text-white text-sm font-semibold flex items-center justify-center" id="progressBar">0%</div>
+    </div>
+
+    <div id="statusMessage" class="mt-4 p-4 rounded-xl text-center text-gray-700 bg-blue-50 border border-blue-200 hidden">
+        업로드 상태가 여기에 표시됩니다.
+    </div>
+
+    <div id="resultContainer" class="mt-6 p-4 bg-gray-50 rounded-xl border border-gray-200 shadow-sm hidden">
+        <h3 class="text-xl font-bold text-gray-800 mb-3">업로드 결과:</h3>
+        <p class="text-gray-700 break-words">
+            <span class="font-semibold">파일 키:</span> <span id="resultFileKey" class="text-blue-700"></span><br>
+            <span class="font-semibold">최종 URL:</span> <span id="resultUrl" class="text-green-700"></span>
+        </p>
+        <button id="copyUrlButton" class="mt-4 bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-4 rounded-lg transition duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-green-300">
+            URL 복사
+        </button>
+    </div>
+
+    <div id="messageBox" class="fixed inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center z-50 hidden">
+        <div class="bg-white p-6 rounded-xl shadow-xl max-w-sm w-full text-center space-y-4">
+            <p id="messageBoxContent" class="text-lg font-semibold text-gray-800"></p>
+            <button id="messageBoxClose" class="bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-5 rounded-lg transition duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-300">
+                확인
+            </button>
+        </div>
+    </div>
+</div>
+<script>
+    // 중요: 이 URL을 실제 백엔드 API의 기본 URL로 변경해주세요.
+    // 예를 들어, "http://localhost:8080" 또는 "https://your-api-domain.com"
+    const API_BASE_URL = 'http://localhost:8080'; // <-- 여기에 실제 백엔드 URL을 입력하세요!
+    const PART_SIZE = 6 * 1024 * 1024; // 6MB (백엔드 PART_SIZE와 일치)
+
+    let selectedFile = null;
+    let uploadId = null;
+    let fileKey = null;
+    let etags = [];
+    let completedParts = 0;
+    let totalParts = 0;
+    let isAborting = false;
+
+    const fileInput = document.getElementById('fileInput');
+    const uploadButton = document.getElementById('uploadButton');
+    const abortButton = document.getElementById('abortButton');
+    const statusMessage = document.getElementById('statusMessage');
+    const progressContainer = document.getElementById('progressContainer');
+    const progressBar = document.getElementById('progressBar');
+    const resultContainer = document.getElementById('resultContainer');
+    const resultFileKey = document.getElementById('resultFileKey');
+    const resultUrl = document.getElementById('resultUrl');
+    const copyUrlButton = document.getElementById('copyUrlButton');
+    const messageBox = document.getElementById('messageBox');
+    const messageBoxContent = document.getElementById('messageBoxContent');
+    const messageBoxClose = document.getElementById('messageBoxClose');
+
+    // 메시지 박스 표시 함수
+    function showMessageBox(message) {
+        messageBoxContent.textContent = message;
+        messageBox.classList.remove('hidden');
+    }
+
+    // 메시지 박스 닫기 함수
+    function closeMessageBox() {
+        messageBox.classList.add('hidden');
+    }
+
+    messageBoxClose.addEventListener('click', closeMessageBox);
+
+    fileInput.addEventListener('change', (event) => {
+        selectedFile = event.target.files[0];
+        if (selectedFile) {
+            statusMessage.textContent = `파일 선택됨: ${selectedFile.name} (${(selectedFile.size / (1024 * 1024)).toFixed(2)} MB)`;
+            statusMessage.classList.remove('hidden');
+            uploadButton.disabled = false;
+            resetUploadState();
+        } else {
+            statusMessage.textContent = '파일이 선택되지 않았습니다.';
+            statusMessage.classList.remove('hidden');
+            uploadButton.disabled = true;
+        }
+    });
+
+    uploadButton.addEventListener('click', startUpload);
+    abortButton.addEventListener('click', abortUpload);
+    copyUrlButton.addEventListener('click', copyUrlToClipboard);
+
+    function resetUploadState() {
+        uploadId = null;
+        fileKey = null;
+        etags = [];
+        completedParts = 0;
+        totalParts = 0;
+        isAborting = false;
+        progressBar.style.width = '0%';
+        progressBar.textContent = '0%';
+        progressContainer.classList.add('hidden');
+        resultContainer.classList.add('hidden');
+        abortButton.classList.add('hidden');
+        statusMessage.classList.remove('bg-red-100', 'border-red-300', 'text-red-800');
+        statusMessage.classList.remove('bg-green-100', 'border-green-300', 'text-green-800');
+        statusMessage.classList.add('bg-blue-50', 'border-blue-200', 'text-gray-700');
+    }
+
+    async function startUpload() {
+        if (!selectedFile) {
+            showMessageBox('먼저 동영상 파일을 선택해주세요.');
+            return;
+        }
+
+        uploadButton.disabled = true;
+        abortButton.classList.remove('hidden');
+        progressContainer.classList.remove('hidden');
+        setStatus('업로드 초기화 중...', 'blue');
+
+        try {
+            // 1. 멀티파트 업로드 초기화 요청
+            const initResponse = await fetch(`${API_BASE_URL}/api/attachments/videos/init`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    fileName: selectedFile.name,
+                    contentType: selectedFile.type,
+                    fileSize: selectedFile.size
+                })
+            });
+
+            if (!initResponse.ok) {
+                const errorData = await initResponse.json();
+                throw new Error(`업로드 초기화 실패: ${errorData.message || initResponse.statusText}`);
+            }
+
+            const data = await initResponse.json();
+            const { uploadId: receivedUploadId, fileKey: receivedFileKey, presignedUrls, partCount } = data.data;
+
+            uploadId = receivedUploadId;
+            fileKey = receivedFileKey;
+            totalParts = partCount;
+            etags = [];
+            completedParts = 0;
+
+            setStatus(`업로드 시작: 총 ${totalParts} 파트`, 'blue');
+
+            // 2. 각 파트 업로드
+            for (let i = 0; i < presignedUrls.length; i++) {
+                if (isAborting) {
+                    setStatus('업로드 중단됨.', 'red');
+                    return;
+                }
+
+                const partNumber = i + 1;
+                const start = i * PART_SIZE;
+                const end = Math.min(start + PART_SIZE, selectedFile.size);
+                const chunk = selectedFile.slice(start, end);
+
+                setStatus(`파트 ${partNumber}/${totalParts} 업로드 중...`, 'blue');
+
+                const uploadPartResponse = await fetch(presignedUrls[i], {
+                    method: 'PUT',
+                    body: chunk,
+                    headers: {
+                        'Content-Type': selectedFile.type // 각 파트의 Content-Type도 중요
+                    }
+                });
+
+                if (!uploadPartResponse.ok) {
+                    throw new Error(`파트 ${partNumber} 업로드 실패: ${uploadPartResponse.statusText}`);
+                }
+
+                const etag = uploadPartResponse.headers.get('ETag');
+                etags.push({ partNumber: partNumber, eTag: etag.replace(/"/g, '') }); // ETag에서 큰따옴표 제거
+
+                completedParts++;
+                updateProgress();
+            }
+
+            // 3. 멀티파트 업로드 완료 요청
+            setStatus('업로드 완료 요청 중...', 'blue');
+            const completeResponse = await fetch(`${API_BASE_URL}/api/attachments/videos/complete`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    uploadId: uploadId,
+                    fileKey: fileKey, // fileKey도 함께 보냄
+                    completedParts: etags
+                })
+            });
+
+            if (!completeResponse.ok) {
+                const errorData = await completeResponse.json();
+                throw new Error(`업로드 완료 실패: ${errorData.message || completeResponse.statusText}`);
+            }
+
+            // 응답 객체 구조가 변경되었습니다. data.videoUrl에서 최종 URL을 추출합니다.
+            const completeData = await completeResponse.json();
+            const finalS3Url = completeData.data.videoUrl; // <-- 이 부분을 수정했습니다.
+
+            setStatus('업로드 완료! 🎉', 'green');
+            showResult(fileKey, finalS3Url);
+
+        } catch (error) {
+            setStatus(`업로드 오류: ${error.message}`, 'red');
+            showMessageBox(`업로드 중 오류 발생: ${error.message}`);
+            console.error('업로드 실패:', error);
+            if (uploadId && !isAborting) {
+                // 오류 발생 시에도 업로드 중단 로직 호출 (선택 사항, 클라이언트에서만 필요할 경우)
+                // await abortUploadOnFailure(fileKey, uploadId);
+            }
+        } finally {
+            uploadButton.disabled = false;
+            abortButton.classList.add('hidden');
+        }
+    }
+
+    async function abortUpload() {
+        if (!uploadId || !fileKey) {
+            showMessageBox('중단할 업로드가 없습니다.');
+            return;
+        }
+
+        isAborting = true; // 업로드 루프 중단 플래그 설정
+        setStatus('업로드 중단 요청 중...', 'red');
+        uploadButton.disabled = true;
+        abortButton.disabled = true;
+
+        try {
+            const abortRequest = await fetch(`${API_BASE_URL}/api/attachments/videos/abort`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    fileKey: fileKey,
+                    uploadId: uploadId
+                })
+            });
+
+            if (!abortRequest.ok) {
+                const errorData = await abortRequest.json();
+                throw new Error(`업로드 중단 실패: ${errorData.message || abortRequest.statusText}`);
+            }
+
+            setStatus('업로드가 성공적으로 중단되었습니다.', 'red');
+            resetUploadState(); // 상태 초기화
+        } catch (error) {
+            setStatus(`업로드 중단 오류: ${error.message}`, 'red');
+            showMessageBox(`업로드 중단 중 오류 발생: ${error.message}`);
+            console.error('업로드 중단 실패:', error);
+        } finally {
+            uploadButton.disabled = false;
+            abortButton.disabled = false;
+            abortButton.classList.add('hidden');
+        }
+    }
+
+    function updateProgress() {
+        const percentage = totalParts > 0 ? (completedParts / totalParts) * 100 : 0;
+        progressBar.style.width = `${percentage.toFixed(0)}%`;
+        progressBar.textContent = `${percentage.toFixed(0)}%`;
+    }
+
+    function setStatus(message, type = 'blue') {
+        statusMessage.textContent = message;
+        statusMessage.classList.remove('hidden', 'bg-blue-50', 'border-blue-200', 'bg-red-100', 'border-red-300', 'text-red-800', 'bg-green-100', 'border-green-300', 'text-green-800');
+        if (type === 'blue') {
+            statusMessage.classList.add('bg-blue-50', 'border-blue-200', 'text-gray-700');
+        } else if (type === 'red') {
+            statusMessage.classList.add('bg-red-100', 'border-red-300', 'text-red-800');
+        } else if (type === 'green') {
+            statusMessage.classList.add('bg-green-100', 'border-green-300', 'text-green-800');
+        }
+    }
+
+    function showResult(fileKey, url) {
+        resultContainer.classList.remove('hidden');
+        resultFileKey.textContent = fileKey;
+        resultUrl.textContent = url;
+    }
+
+    function copyUrlToClipboard() {
+        const url = resultUrl.textContent;
+        if (url) {
+            const tempInput = document.createElement('textarea');
+            tempInput.value = url;
+            document.body.appendChild(tempInput);
+            tempInput.select();
+            try {
+                document.execCommand('copy');
+                showMessageBox('URL이 클립보드에 복사되었습니다!');
+            } catch (err) {
+                showMessageBox('URL 복사 실패: 브라우저가 지원하지 않거나 권한이 없습니다.');
+                console.error('클립보드 복사 실패:', err);
+            }
+            document.body.removeChild(tempInput);
+        }
+    }
+
+    // 초기 상태 설정
+    uploadButton.disabled = true; // 파일 선택 전에는 비활성화
+    setStatus('업로드를 시작하려면 동영상 파일을 선택하세요.', 'blue');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 📝 개요
첨부파일(이미지, 영상) 업로드를 구현했습니다.

## ✨ 주요 변경사항
* AWS S3를 활용하여 이미지 업로드 구현
* AWS S3를 활용하여 Pre-singed URL 기반 멀티파트 영상 업로드 구현
  * 중간 서버를 거치지 않기 때문에 네트워크 지연 감소 및 비용 절감 효과를 챙겼습니다.
  * S3단일 PUT 제한은 5GB 이기에 멀티파트를 활용하여 그 용량을 넘는 대용량 영상의 업로드를 가능하게 했습니다.
  * 각 파트의 업로드 완료 여부를 추적하여 사용자에게 업로드 진행률을 손쉽게 표시할 수 있습니다.
* `attachment` DB 스키마 테이블 추가
* 영상 업로드 테스트용 프론트 구현
  * 정상 동작하기에 프론트를 구현할 때 참고하시면 좋습니다.

## 🛠️ 상세 내용
* 영상 업로드 로직
1. 클라이언트 -> 서버: 업로드 요청
2. 서버: 멀티파트 업로드 초기화, 파트 계산, 각 파트별 Pre-signed URL 생성
3. 서버 -> 클라이언트: S3 업로드에 필요한 정보들을 반환
4. 클라이언트: 영상을 정해진 크기와 개수로 나누어서 Pre-signed URL 기반 파트별로 순서대로 업로드
5. 클라이언트 -> 서버: 업로드 성공 후 각 파트에 대한 `ETag` 목록과 함께 업로드 완료 요청을 보냄
6. 서버 -> S3: 각 파트의 ETag를 S3로 보내어 S3는 모든 파트가 올바르게 업로드되었는지 확인하고, 최종적으로 파일 병합
  

## 📌 기타
![image](https://github.com/user-attachments/assets/0bfcc2d9-12f7-43b7-b1ef-1c2a3daac487)
* 영상 업로드 테스트용 프론트입니다.
* 영상을 정해진 용량과 개수로 나누어서 파트별로 업로드 한 후 성공한 모습입니다.
* 정상 동작하기에 프론트를 구현할 때 참고하시면 좋습니다.

## 🔗 관련 이슈
This closes #21 