### PR TITLE
feat: 공통 예외 정의 및 예외 처리 구현

### DIFF
--- a/src/main/java/com/verdict/verdict/dto/ImageFile.java
+++ b/src/main/java/com/verdict/verdict/dto/ImageFile.java
@@ -1,5 +1,6 @@
 package com.verdict.verdict.dto;
 
+import com.verdict.verdict.exception.image.ImageException;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,7 +21,7 @@ public class ImageFile {
 
     private void validateNullImage(MultipartFile file) {
         if (file.isEmpty()) {
-            throw new RuntimeException("이미지가 존재하지 않습니다."); //TODO: ImageException
+            throw new ImageException("이미지가 존재하지 않습니다.");
         }
     }
 

--- a/src/main/java/com/verdict/verdict/exception/BadRequestException.java
+++ b/src/main/java/com/verdict/verdict/exception/BadRequestException.java
@@ -1,0 +1,9 @@
+package com.verdict.verdict.exception;
+
+public class BadRequestException extends RuntimeException {
+    private static final String MESSAGE = "잘못된 요청입니다.";
+
+    public BadRequestException() {super(MESSAGE);}
+
+    public BadRequestException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/ConflictException.java
+++ b/src/main/java/com/verdict/verdict/exception/ConflictException.java
@@ -1,0 +1,9 @@
+package com.verdict.verdict.exception;
+
+public class ConflictException extends RuntimeException{
+    private static final String MESSAGE = "현재 리소스의 상태와 충돌합니다.";
+
+    public ConflictException() {super(MESSAGE);}
+
+    public ConflictException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/ForbiddenException.java
+++ b/src/main/java/com/verdict/verdict/exception/ForbiddenException.java
@@ -1,0 +1,9 @@
+package com.verdict.verdict.exception;
+
+public class ForbiddenException extends RuntimeException{
+    private static final String MESSAGE = "해당 리소스에 접근할 권한이 없습니다.";
+
+    public ForbiddenException() {super(MESSAGE);}
+
+    public ForbiddenException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/NotFoundException.java
+++ b/src/main/java/com/verdict/verdict/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package com.verdict.verdict.exception;
+
+public class NotFoundException extends RuntimeException {
+    private static final String MESSAGE = "리소스를 찾을 수 없습니다.";
+
+    public NotFoundException() {super(MESSAGE);}
+
+    public NotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/UnauthorizedException.java
+++ b/src/main/java/com/verdict/verdict/exception/UnauthorizedException.java
@@ -1,0 +1,9 @@
+package com.verdict.verdict.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    private static final String MESSAGE = "인증이 필요합니다.";
+
+    public UnauthorizedException() {super(MESSAGE);}
+
+    public UnauthorizedException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/attachment/AttachmentNotFoundException.java
+++ b/src/main/java/com/verdict/verdict/exception/attachment/AttachmentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.verdict.verdict.exception.attachment;
+
+import com.verdict.verdict.exception.NotFoundException;
+
+public class AttachmentNotFoundException extends NotFoundException {
+    private static final String MESSAGE = "해당 첨부파일을 찾을 수 없습니다.";
+
+    public AttachmentNotFoundException() {super(MESSAGE);}
+
+    public AttachmentNotFoundException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/image/ImageException.java
+++ b/src/main/java/com/verdict/verdict/exception/image/ImageException.java
@@ -1,0 +1,11 @@
+package com.verdict.verdict.exception.image;
+
+import com.verdict.verdict.exception.BadRequestException;
+
+public class ImageException extends BadRequestException {
+    private static final String MESSAGE = "이미지 관련 문제가 발생했습니다.";
+
+    public ImageException() {super(MESSAGE);}
+
+    public ImageException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/exception/video/VideoException.java
+++ b/src/main/java/com/verdict/verdict/exception/video/VideoException.java
@@ -1,0 +1,11 @@
+package com.verdict.verdict.exception.video;
+
+import com.verdict.verdict.exception.BadRequestException;
+
+public class VideoException extends BadRequestException {
+    private static final String MESSAGE = "이미지 관련 문제가 발생했습니다.";
+
+    public VideoException() {super(MESSAGE);}
+
+    public VideoException(String message) {super(message);}
+}

--- a/src/main/java/com/verdict/verdict/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/verdict/verdict/handler/GlobalExceptionHandler.java
@@ -1,0 +1,103 @@
+package com.verdict.verdict.handler;
+
+import com.verdict.verdict.dto.ApiResponse;
+import com.verdict.verdict.exception.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ApiResponse<Object>> handleBadRequestException(BadRequestException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.BAD_REQUEST; // 400 Bad Request
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    // 인증되지 않았을 때
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ApiResponse<Object>> handleAuthenticationException(UnauthorizedException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.UNAUTHORIZED; // 401 Unauthorized
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    // 인증은 되었지만, 해당 자원에 대한 접근 권한이 없을 때
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ApiResponse<Object>> handleForbiddenException(ForbiddenException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.FORBIDDEN; // 403 Forbidden
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ApiResponse<Object>> handleNotFoundException(NotFoundException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.NOT_FOUND; // 404 Not Found
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiResponse<Object>> handleConflictException(ConflictException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.CONFLICT; // 409 Conflict
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception e) {
+        log.error("Unhandled exception", e);
+
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR; // 500 Internal Server Error
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, e.getMessage(), null));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Object>> handleValidationException(MethodArgumentNotValidException e) {
+        log.error(e.getMessage());
+
+        BindingResult bindingResult = e.getBindingResult();
+
+        HttpStatus status = HttpStatus.BAD_REQUEST; // 400 Bad Request
+
+        List<String> errorMessages = bindingResult.getFieldErrors().stream()
+                .map(fieldError -> String.format("[%s](은)는 %s 입력된 값: [%s]",
+                        fieldError.getField(),
+                        fieldError.getDefaultMessage(),
+                        fieldError.getRejectedValue()))
+                .toList();
+        return ResponseEntity.status(status).body(ApiResponse.of(status, errorMessages, null));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ApiResponse<Object>> handleMissingParam(MissingServletRequestParameterException e) {
+        log.error(e.getMessage());
+
+        HttpStatus status = HttpStatus.BAD_REQUEST; // 400 Bad Request
+
+        List<String> errorMessages = List.of(e.getMessage());
+
+        return ResponseEntity.status(status).body(ApiResponse.of(status, errorMessages, null));
+    }
+}

--- a/src/main/java/com/verdict/verdict/infrastructure/S3ImageService.java
+++ b/src/main/java/com/verdict/verdict/infrastructure/S3ImageService.java
@@ -2,6 +2,7 @@ package com.verdict.verdict.infrastructure;
 
 import com.verdict.verdict.dto.ImageFile;
 import com.verdict.verdict.dto.ImageUploadResult;
+import com.verdict.verdict.exception.image.ImageException;
 import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Resource;
 import io.awspring.cloud.s3.S3Template;
@@ -41,7 +42,7 @@ public class S3ImageService {
 
             return new ImageUploadResult(url, fileKey);
         } catch (IOException | RuntimeException e) {
-            throw new RuntimeException("이미지 업로드에 실패했습니다. " + e.getMessage()); //TODO: ImageException
+            throw new ImageException("이미지 업로드에 실패했습니다. " + e.getMessage());
         }
     }
 
@@ -51,7 +52,7 @@ public class S3ImageService {
         try {
             s3Template.deleteObject(bucket, fileKey);
         } catch (RuntimeException e) {
-            throw new RuntimeException("이미지 삭제에 실패했습니다. " + e.getMessage());
+            throw new ImageException("이미지 삭제에 실패했습니다. " + e.getMessage());
         }
     }
 }

--- a/src/main/java/com/verdict/verdict/infrastructure/S3VideoService.java
+++ b/src/main/java/com/verdict/verdict/infrastructure/S3VideoService.java
@@ -3,6 +3,7 @@ package com.verdict.verdict.infrastructure;
 import com.verdict.verdict.dto.request.VideoUploadCompletedRequest;
 import com.verdict.verdict.dto.request.VideoUploadInitRequest;
 import com.verdict.verdict.dto.response.VideoUploadInitResponse;
+import com.verdict.verdict.exception.video.VideoException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -65,7 +66,7 @@ public class S3VideoService {
                     PART_SIZE
             );
         } catch (RuntimeException e) {
-            throw new RuntimeException("S3 멀티파트 업로드 초기화에 실패했습니다. " + e.getMessage()); // TODO: VideoException
+            throw new VideoException("S3 멀티파트 업로드 초기화에 실패했습니다. " + e.getMessage());
         }
     }
 
@@ -107,7 +108,7 @@ public class S3VideoService {
             CompleteMultipartUploadResponse response = s3Client.completeMultipartUpload(completeRequest);
             return response.location(); // 최종 파일의 S3 URL
         } catch (RuntimeException e) {
-            throw new RuntimeException("멀티파트 업로드 완료에 실패했습니다. " + e.getMessage()); // TODO: VideoException
+            throw new VideoException("멀티파트 업로드 완료에 실패했습니다. " + e.getMessage());
         }
     }
 
@@ -121,7 +122,7 @@ public class S3VideoService {
                     .build();
             s3Client.abortMultipartUpload(request);
         } catch (RuntimeException e) {
-            throw new RuntimeException("멀티파트 업로드 중단에 실패했습니다. " + e.getMessage()); // TODO: VideoException
+            throw new VideoException("멀티파트 업로드 중단에 실패했습니다. " + e.getMessage());
         }
     }
 
@@ -136,7 +137,7 @@ public class S3VideoService {
                     .build();
             s3Client.deleteObject(request);
         }catch (RuntimeException e) {
-            throw new RuntimeException("파일 삭제에 실패했습니다. " + e.getMessage()); //TODO: VideoException
+            throw new VideoException("영상 삭제에 실패했습니다. " + e.getMessage()); //
         }
     }
 }

--- a/src/main/java/com/verdict/verdict/service/ImageService.java
+++ b/src/main/java/com/verdict/verdict/service/ImageService.java
@@ -4,6 +4,7 @@ import com.verdict.verdict.dto.ImageFile;
 import com.verdict.verdict.dto.ImageUploadResult;
 import com.verdict.verdict.dto.response.ImageResponse;
 import com.verdict.verdict.entity.Attachment;
+import com.verdict.verdict.exception.image.ImageException;
 import com.verdict.verdict.infrastructure.S3ImageService;
 import com.verdict.verdict.repository.AttachmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class ImageService {
 
     private void validateSizeOfImage(MultipartFile image) {
         if (image == null || image.isEmpty()) {
-            throw new RuntimeException("이미지가 존재하지 않습니다."); //TODO: ImageException
+            throw new ImageException("이미지가 존재하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/verdict/verdict/service/VideoService.java
+++ b/src/main/java/com/verdict/verdict/service/VideoService.java
@@ -6,6 +6,7 @@ import com.verdict.verdict.dto.response.VideoResponse;
 import com.verdict.verdict.dto.response.VideoUploadInitResponse;
 import com.verdict.verdict.entity.Attachment;
 import com.verdict.verdict.entity.AttachmentStatus;
+import com.verdict.verdict.exception.attachment.AttachmentNotFoundException;
 import com.verdict.verdict.infrastructure.S3VideoService;
 import com.verdict.verdict.repository.AttachmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,7 @@ public class VideoService {
         // 멀티파트 업로드 완료 처리
         String url = s3VideoService.completeMultipartUpload(request);
         //TODO: AttachmentNotFoundException
-        Attachment attachment = attachmentRepository.findByFileKey(request.getFileKey()).orElseThrow(RuntimeException::new);
+        Attachment attachment = attachmentRepository.findByFileKey(request.getFileKey()).orElseThrow(AttachmentNotFoundException::new);
 
         attachment.updateStatus(AttachmentStatus.UPLOADED);
 
@@ -59,14 +60,14 @@ public class VideoService {
     public void abortVideoUpload(String fileKey, String uploadId) {
         s3VideoService.abortMultipartUpload(fileKey, uploadId);
 
-        Attachment attachment = attachmentRepository.findByFileKey(fileKey).orElseThrow(RuntimeException::new);
+        Attachment attachment = attachmentRepository.findByFileKey(fileKey).orElseThrow(AttachmentNotFoundException::new);
         attachment.updateStatus(AttachmentStatus.FAILED);
     }
 
     // S3 비디오 삭제 처리
     @Transactional
     public void deleteVideo(String fileKey) {
-        Attachment attachment = attachmentRepository.findByFileKey(fileKey).orElseThrow(RuntimeException::new);
+        Attachment attachment = attachmentRepository.findByFileKey(fileKey).orElseThrow(AttachmentNotFoundException::new);
 
         s3VideoService.deleteVideo(fileKey);
 


### PR DESCRIPTION
## 📝 개요
커스텀 예외들이 상속받아서 사용할 공통 예외 정의 및 예외 처리 구현을 하였습니다.

## ✨ 주요 변경사항
* feat: 공통 예외 정의
* feat: 이미지 업로드 커스텀 예외 정의 및 기존 코드 수정
* feat: 첨부파일(영상) 업로드 커스텀 예외 정의 및 기존 코드 수정
* feat: 예외 처리 핸들러 구현
  * 이제 예외 발생시 body 에 `ApiResponse`  에 감싸여진 미리 정해둔 예외 메시지를 반환합니다.

## 🛠️ 상세 내용
* 공통 예외
  * `BadRequestException` : 400 Bad Request
  * `UnauthorizedException` : 401 Unauthorized (인증되지 않음)
  * `ForbiddenException` : 403 Forbidden (접근 권한 없음)
  * `NotFoundException` : 404 Not Found
  * `ConflictException` : 409 Conflict

커스텀 예외를 구현하실 때 위의 공통 예외 중 하나를 상속받아 구현하시면 됩니다(필요 시 공통 예외를 추가하셔도 됩니다).

## 🔗 관련 이슈
This closes #29 